### PR TITLE
荒尾市のservice_catalog作成時にベクトル情報の作成処理を追加

### DIFF
--- a/LocalGovData/432041_city_arao/ServiceCatalogCreator/pipeline/html2htaglayer_step.py
+++ b/LocalGovData/432041_city_arao/ServiceCatalogCreator/pipeline/html2htaglayer_step.py
@@ -3,9 +3,12 @@ import json
 import yaml
 import hashlib
 import pandas as pd
+import torch
+import numpy as np
 from bs4 import BeautifulSoup
 from lib.column_manager import ColumnManager
 from lib.htag_node import  HTagNode as Node
+from transformers import BertTokenizer, BertModel
 
 
 class HtmlConverter:

--- a/LocalGovData/432041_city_arao/ServiceCatalogCreator/pipeline/html2htaglayer_step.py
+++ b/LocalGovData/432041_city_arao/ServiceCatalogCreator/pipeline/html2htaglayer_step.py
@@ -126,7 +126,7 @@ class Html2HtagLayerStep:
             details_dict_list = [{str(key): value for key, value in record.items()} for record in details_dict_list]
         else:
             details_dict_list = details
-       
+
         # JSON 形式でシリアライズするためには、リスト全体をダンプする
         details_str = json.dumps(details_dict_list, sort_keys=True)
         return hashlib.sha256(details_str.encode('utf-8')).hexdigest()
@@ -183,8 +183,7 @@ class Html2HtagLayerStep:
                         print(f"  error URL : {url}")
                 else:
                     print(f'処理対象の単語がふくまれていません')
-                
-                    
+
         self.save_json(unique_tables, self.output_json_dir)
 
     def should_process(self, soup):

--- a/LocalGovData/432041_city_arao/ServiceCatalogCreator/pipeline/html2htaglayer_step.py
+++ b/LocalGovData/432041_city_arao/ServiceCatalogCreator/pipeline/html2htaglayer_step.py
@@ -274,7 +274,7 @@ class Html2HtagLayerStep:
                 entries.append(entry)
 
         # JSONデータとして保存
-        self.save_embeddings_to_file(overview_embeddings, entries, f'{file_path}/overview_embeddings.json')
+        self.save_embeddings_to_file(overview_embeddings, entries, f'{file_path}/service_catalog_embeddings.json')
 
     def get_embedding(self, text):
         """

--- a/LocalGovData/432041_city_arao/ServiceCatalogCreator/pipeline/html2htaglayer_step.py
+++ b/LocalGovData/432041_city_arao/ServiceCatalogCreator/pipeline/html2htaglayer_step.py
@@ -285,7 +285,7 @@ class Html2HtagLayerStep:
         inputs = self.tokenizer(text, return_tensors='pt', max_length=512, truncation=True)
         outputs = self.model(**inputs)
         embedding = outputs.last_hidden_state.mean(dim=1)
-        return embedding.detach().numpy()
+        return embedding.squeeze(0).detach().numpy()
 
     def save_embeddings_to_file(self, embeddings, entries, output_file):
         """

--- a/LocalGovData/432041_city_arao/ServiceCatalogCreator/pipeline/html2htaglayer_step.py
+++ b/LocalGovData/432041_city_arao/ServiceCatalogCreator/pipeline/html2htaglayer_step.py
@@ -103,6 +103,9 @@ class Html2HtagLayerStep:
         self.output_json_dir = step_config['output_json_dir']
         self.columns_yaml = step_config['columns_yaml']
         self.url_mapping = self.load_mapping()
+        # BERTモデルとトークナイザーの初期化
+        self.tokenizer = BertTokenizer.from_pretrained('cl-tohoku/bert-base-japanese-v3')
+        self.model = BertModel.from_pretrained('cl-tohoku/bert-base-japanese-v3')
         os.makedirs(self.output_json_dir, exist_ok=True)
 
         self.column_manager = ColumnManager(self.columns_yaml)
@@ -188,6 +191,7 @@ class Html2HtagLayerStep:
                     print(f'処理対象の単語がふくまれていません')
 
         self.save_json(unique_tables, self.output_json_dir)
+        self.save_embedding(unique_tables, self.output_json_dir)
 
     def should_process(self, soup):
         main_div = soup.find('div', id='contents')
@@ -236,3 +240,63 @@ class Html2HtagLayerStep:
         with open(file_path, 'r', encoding='utf-8') as f:
             data = json.load(f)
             print(data)
+
+    def save_embedding(self, data, file_path):
+        """
+        サービス情報の概要テキストをベクトル化し、JSONファイルに保存する
+        :param data: サービス情報のリスト
+        :param file_path: 保存先のファイルパス
+        """
+        overview_embeddings = []
+        entries = []
+
+        for service in data:
+            # 概要テキストを取得
+            overview_items = service.get('概要', {}).get('items', [])
+            if isinstance(overview_items, list):
+                overview = " ".join(overview_items)
+            elif isinstance(overview_items, str):
+                overview = overview_items
+            else:
+                print(f"Invalid format: {overview_items}")
+                continue  # 不正な形式はスキップ
+
+            # テキストが空でない場合のみ処理
+            if overview:
+                embedding = self.get_embedding(overview)
+                overview_embeddings.append(embedding)
+
+                entry = {
+                    'overview': overview,
+                    'formal_name': service.get('正式名称', {}).get('items', ['N/A'])[0],
+                    'url': service.get('URL', {}).get('items', 'N/A')
+                }
+                entries.append(entry)
+
+        # JSONデータとして保存
+        self.save_embeddings_to_file(overview_embeddings, entries, f'{file_path}/overview_embeddings.json')
+
+    def get_embedding(self, text):
+        """
+        テキストをBERTモデルを使用してベクトル化する
+        :param text: テキスト
+        :return: ベクトルデータ
+        """
+        inputs = self.tokenizer(text, return_tensors='pt', max_length=512, truncation=True)
+        outputs = self.model(**inputs)
+        embedding = outputs.last_hidden_state.mean(dim=1)
+        return embedding.detach().numpy()
+
+    def save_embeddings_to_file(self, embeddings, entries, output_file):
+        """
+        ベクトルデータをJSONファイルに保存する
+        :param embeddings: ベクトルデータのリスト
+        :param entries: サービス情報のリスト
+        :param output_file: 保存先のファイルパス
+        """
+        data = {
+            'embeddings': np.array(embeddings).tolist(),
+            'entries': entries
+        }
+        with open(output_file, 'w', encoding='utf-8') as f:
+            json.dump(data, f, ensure_ascii=False, indent=4)

--- a/LocalGovData/432041_city_arao/ServiceCatalogCreator/pipeline/requirements.txt
+++ b/LocalGovData/432041_city_arao/ServiceCatalogCreator/pipeline/requirements.txt
@@ -8,3 +8,5 @@ numpy==1.19.5
 pandas
 lxml
 html5lib
+transformers==4.45.2
+torch==2.5.0


### PR DESCRIPTION
## WHAT

荒尾市のservice_catalog作成時にベクトル情報の作成処理を追加しました。

pipelineを実行するとservice_catalogと同じ階層にservice_catalog_embeddings.jsonを作成する様変更

![スクリーンショット 2024-10-21 0 34 51](https://github.com/user-attachments/assets/49555bd3-dcd8-46f9-b846-39ffaedc6467)


生成されるJSONのサンプル
```json
{
    "embeddings": [
        [
            [
                0.036898065358400345,
                -0.12357139587402344,
                -0.08561267703771591,
                -0.08673013001680374,
                -0.08293900638818741
            ]
        ]
    ],
    "entries": [
        {
            "overview": "test1",
            "formal_name": "荒尾市出産・子育て応援給付金支給事業",
            "url": "https://www.city.arao.lg.jp/xxxx.html"
        },
        {
            "overview": "使用済みインクカートリッジ及びトナーカートリッジの回収を始めました 2019年8月30日",
            "formal_name": "使用済みインクカートリッジ及びトナーカートリッジの回収を始めました",
            "url": "https://www.city.arao.lg.jp/xxxx.html"
        }
    ]
}
```